### PR TITLE
Django 1.6 compatibility

### DIFF
--- a/src/prefetch.py
+++ b/src/prefetch.py
@@ -36,7 +36,7 @@ class PrefetchManagerMixin(models.Manager):
         Django <1.6 compatibility method.
         """
 
-        return get_queryset(self)
+        return self.get_queryset(self)
 
     def prefetch(self, *args):
         return self.get_queryset().prefetch(*args)


### PR DESCRIPTION
Django 1.6 is using get_queryset rather than get_query_set.  This commit fixes this, and still manages the support for earlier versions.
